### PR TITLE
Disable version increment check

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,6 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
+check-version-increment: false
 target-branch: main
 chart-dirs:
   - chart


### PR DESCRIPTION
Disable version increment check because the version is automatically updated during the release workflow.