### PR TITLE
Remove skip namespace option and set system-domain as mandatory option

### DIFF
--- a/chart/epinio/questions.yml
+++ b/chart/epinio/questions.yml
@@ -33,7 +33,7 @@ questions:
   label: Domain
   description: "Domain for the application"
   type: strings
-  required: false
+  required: true
   group: "General settings"
 - variable: accessControlAllowOrigin
   label: Access control allow origin

--- a/chart/epinio/templates/post-install.yaml
+++ b/chart/epinio/templates/post-install.yaml
@@ -33,6 +33,7 @@ spec:
           - /epinio
         args:
           - install
+          - "--system-domain={{ .Values.domain }}"
           - "--email-address={{ .Values.email | default "epinio@suse.com" }}"
           - "--tls-issuer={{ .Values.tlsIssuer | default "epinio-ca" }}"
 {{- if .Values.accessControlAllowOrigin }}
@@ -76,9 +77,6 @@ spec:
 {{ end }}
 {{- if .Values.skipTraefik }}
           - "--skip-traefik"
-{{ end }}
-{{- if .Values.domain }}
-          - "--system-domain={{ .Values.domain }}"
 {{ end }}
 {{- if .Values.user }}
           - "--user={{ .Values.user }}"

--- a/chart/epinio/templates/post-install.yaml
+++ b/chart/epinio/templates/post-install.yaml
@@ -34,7 +34,6 @@ spec:
         args:
           - install
           - "--email-address={{ .Values.email | default "epinio@suse.com" }}"
-          - "--skip-default-namespace"
           - "--tls-issuer={{ .Values.tlsIssuer | default "epinio-ca" }}"
 {{- if .Values.accessControlAllowOrigin }}
           - "--access-control-allow-origin={{ .Values.accessControlAllowOrigin }}"

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -11,8 +11,8 @@ email: "epinio@suse.com"
 # The name of the cluster issuer to use. Epinio creates three options: 'epinio-ca', 'letsencrypt-production', and 'selfsigned-issuer'. (default "epinio-ca")
 tlsIssuer: "epinio-ca"
 
-# The domain you are planning to use for Epinio. Should be pointing to the traefik public IP (Leave empty to use a omg.howdoi.website domain).
-# domain: ""
+# The domain you are planning to use for Epinio. Should be pointing to the traefik public IP (mandatory option).
+domain: "localhost.omg.howdoi.website"
 
 # The user name for authenticating all API requests.
 # user: ""


### PR DESCRIPTION
`--skip-default-namespace` option was removed from epinio (https://github.com/epinio/epinio/pull/983/commits/b31fdcdac310919714eb48a7b2ae33c3e9a576a5)
`--system-domain` is now a mandatory option (https://github.com/epinio/epinio/pull/983/commits/f770c645968e24be836c8d734c2c79bec4a92bc0)