### PR TITLE
Add missing permissions to epinio server

### DIFF
--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -87,6 +87,7 @@ rules:
   - get
   - list
   - update
+  - patch
 - apiGroups:
   - servicecatalog.k8s.io
   resources:


### PR DESCRIPTION
It's this change:
https://github.com/epinio/epinio/pull/1038/files#diff-99b83f1054e1f09ee778c6f2fb9bfd57f0eaaf5e30664b8d57b26d4fbc94858dR90

which was made on the chart copy on the epinio/epinio repo.