### PR TITLE
Add a serviceaccount to the default namespace

### DIFF
--- a/chart/epinio/templates/default-app-namespace.yaml
+++ b/chart/epinio/templates/default-app-namespace.yaml
@@ -1,0 +1,22 @@
+---
+# Default namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workspace
+  annotations:
+    linkerd.io/inject: enabled
+  labels:
+    # Instruct kubed to copy image pull secrets over.
+    kubed-sync: "registry-creds"
+    app.kubernetes.io/component: "epinio-namespace"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: workspace
+  namespace: workspace
+imagePullSecrets:
+- name: registry-creds

--- a/chart/epinio/templates/tekton-staging-namespace.yaml
+++ b/chart/epinio/templates/tekton-staging-namespace.yaml
@@ -10,16 +10,3 @@ metadata:
     # label so that kubed copies epinio-registry secret to this namespace
     kubed-registry-tls-from: {{ .Values.registry.certificateSecretNamespace }}
   {{- end }}
-
----
-# Default namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: workspace
-  annotations:
-    linkerd.io/inject: enabled
-  labels:
-    # Instruct kubed to copy image pull secrets over.
-    kubed-sync: "registry-creds"
-    app.kubernetes.io/component: "epinio-namespace"


### PR DESCRIPTION
because that's what the go code is doing when creating a new namespace.
The serviceaccount it needed so that kubernetes can pull from the
registry.