### PR TITLE
Avoid linkerd inject for hook pods

### DIFF
--- a/chart/epinio-installer/Chart.yaml
+++ b/chart/epinio-installer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: epinio-installer
 version: 0.2.2-1
 # This is the version of the epinio/installer image
-appVersion: v0.0.1-14
+appVersion: v0.0.1-15
 description: Deploys Epinio and dependencies automatically
 home: https://github.com/epinio/epinio
 icon: https://raw.githubusercontent.com/epinio/epinio-helm-chart/main/assets/epinio.png

--- a/chart/epinio-installer/templates/post-install.yaml
+++ b/chart/epinio-installer/templates/post-install.yaml
@@ -13,6 +13,7 @@ metadata:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+    "linkerd.io/inject": disabled
 spec:
   backoffLimit: 0
   template:

--- a/chart/epinio-installer/templates/pre-delete.yaml
+++ b/chart/epinio-installer/templates/pre-delete.yaml
@@ -13,6 +13,7 @@ metadata:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+    "linkerd.io/inject": disabled
 spec:
   backoffLimit: 0
   template:


### PR DESCRIPTION
Linkerd sidecar seems to keep us from getting a Kubeconfig?

`install couldn't check kubeconfig; ensure kubeconfig is correct to continue: invalid kube config: Get "https://...`

Also bump installer version.