### PR TITLE
Fix cert-manager issue

### DIFF
--- a/chart/epinio-installer/templates/manifest.yaml
+++ b/chart/epinio-installer/templates/manifest.yaml
@@ -202,8 +202,9 @@ stringData:
             type: annotation
 
       - id: registry
-        # needs: namespace-registry
+        {{- if not .Values.skipCertManager }}
         needs: cert-manager
+        {{- end }}
         namespace: epinio-registry
         type: helm
         source:


### PR DESCRIPTION
We should not rely on cert-manager if it is not installed during Epinio deployment.