### PR TITLE
Casbin configuration

### DIFF
--- a/chart/epinio/templates/configmap-auth.yaml
+++ b/chart/epinio/templates/configmap-auth.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-config
+  namespace: epinio
+data:
+  casbin.conf: |-
+    [request_definition]
+    r = subject, domain, action, resource
+
+    [policy_definition]
+    p = subject, action, resource
+
+    [policy_effect]
+    e = some(where (p.eft == allow))
+
+    [matchers]
+    m = (p.subject == '' || r.subject == p.subject) && keyMatch2(r.resource, p.resource) && (r.domain == keyGet2(r.resource, p.resource, 'namespace') || '' == keyGet2(r.resource, p.resource, 'namespace')) && regexMatch(r.action, p.action) || r.subject == 'admin'
+  policy.csv: |-
+    # public endpoints
+    p,,, /ready
+    p,,, /api/v1/info
+    p,,, /api/v1/authtoken
+    p,,, /api/v1/configurations
+    p,,, /api/v1/services
+    p,,, /api/v1/services/:servicename
+
+    # namespaced endpoints
+    # namespaced-user can do anything on their namespaces 
+    p, namespaced-user, (GET)|(POST)|(PUT)|(DELETE)|(PATCH), /api/v1/namespaces/:namespace/*

--- a/chart/epinio/templates/default-user.yaml
+++ b/chart/epinio/templates/default-user.yaml
@@ -4,8 +4,25 @@ type: BasicAuth
 metadata:
   labels:
     epinio.suse.org/api-user-credentials: "true"
+    epinio.suse.org/role: "admin"
+  name: admin-epinio-user
+  namespace: {{ .Release.Namespace }}
+stringData:
+  username: {{ .Values.api.username }}
+  password: {{ .Values.api.password }}
+---
+apiVersion: v1
+kind: Secret
+type: BasicAuth
+metadata:
+  labels:
+    epinio.suse.org/api-user-credentials: "true"
+    epinio.suse.org/role: "namespaced-user"
   name: default-epinio-user
   namespace: {{ .Release.Namespace }}
 stringData:
-  password: {{ .Values.api.password }}
-  username: {{ .Values.api.username }}
+  username: epinio
+  password: password
+  namespaces: |
+    workspace
+    workspace2

--- a/chart/epinio/templates/server.yaml
+++ b/chart/epinio/templates/server.yaml
@@ -260,6 +260,9 @@ spec:
       volumes:
       - name: tmp-volume
         emptyDir: {}
+      - name: auth-config-volume
+        configMap:
+          name: auth-config
       containers:
         - command: ["/epinio", "server"]
           args: ["--port", "8030"]
@@ -299,6 +302,8 @@ spec:
           volumeMounts:
           - name: tmp-volume
             mountPath: /tmp
+          - name: auth-config-volume
+            mountPath: /etc/config
           readinessProbe:
             httpGet:
               path: /ready


### PR DESCRIPTION
## Note:
Waiting for the

- https://github.com/epinio/helm-charts/pull/184

because the name in the policy needs to match the roles in the users!

---

[Casbin](https://casbin.org/) is an authorization library, that can be used to write flexible policies.

This PR adds the ConfigMap with the Casbin configuration and the policy to apply to some Epinio endpoints.

The configuration and policy can be tested here:  https://casbin.org/casbin-editor/#66P645QYH

## configuration

Ref: https://casbin.org/docs/en/syntax-for-models

### request_definition

The incoming request that will be checked. It has a `subject` (an Epinio role), a `domain` (a namespace), an `action` (the HTTP verb), and a `resource` (the endpoint)

```
[request_definition]
r = subject, domain, action, resource
```

### policy_definition and policy_effect

The policy_definition will tell Casbin how the csv with the policy is defined and the policy_effect what to do. In our case if some policy is matched then it will allow the request

```
[policy_definition]
p = subject, action, resource

[policy_effect]
e = some(where (p.eft == allow))
```

### matchers

The matchers are the most important part

```
[matchers]
m = (p.subject == '' || r.subject == p.subject) && keyMatch2(r.resource, p.resource) && (r.domain == keyGet2(r.resource, p.resource, 'namespace') || '' == keyGet2(r.resource, p.resource, 'namespace')) && regexMatch(r.action, p.action) || r.subject == 'admin'
```

Let's split it.

#### subject

This rule will tell us that a subject is fine if the policy has no subject (so a "public" route) or if it's owned by the same coming from the request
```
(p.subject == '' || r.subject == p.subject)
```

#### resource
The requested resource must match the endpoint. The `keyMatch2` func will check a rule formatted like the one that we have in Gin: `/foo/:namespace/bar`

```
keyMatch2(r.resource, p.resource)
```

#### domain
The `keyGet2` func will fetch the key "namespace" from the resource. If it's empty or matches the one from the request it's fine 
```
(
    r.domain == keyGet2(r.resource, p.resource, 'namespace')
    || 
    '' == keyGet2(r.resource, p.resource, 'namespace')
)
```

#### action
The action will have to match the regex

```
regexMatch(r.action, p.action)
```

so we can eventually define just some verbs, or none, like:

```
p, namespaced-user, (GET)|(POST)|(PUT)|(DELETE)|(PATCH), /api/v1/namespaces/:namespace/*
```

#### admin

The last `||` is the one used by the admin to override anything, so if the request is coming from an admin your good to go!

```
|| r.subject == 'admin'
```