### PR TITLE
Do not automate epinioVersion update

### DIFF
--- a/updatecli/updatecli.d/epinio-ui.yaml
+++ b/updatecli/updatecli.d/epinio-ui.yaml
@@ -61,17 +61,6 @@ targets:
       versionincrement: minor
       appversion: true
 
-  epinio-chart:
-    name: "Update Required Epinio version for Helm Chart chart/epinio-ui"
-    kind: "helmchart"
-    scmid: "helm-charts"
-    sourceid: "epinio"
-    spec:
-      name: "chart/epinio-ui"
-      file: "values.yaml"
-      key: "epinioVersion"
-      versionincrement: patch
-
 # Define pullrequest configuration if one needs to be created
 pullrequests:
   helm-charts:


### PR DESCRIPTION
It appears that epinioVersion is not used anymore which break updatecli execution as showned [here|https://github.com/epinio/helm-charts/actions/workflows/updatecli.yml]

@richard-cox Could you confirm that we can disble this automation

Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>