### PR TITLE
fix: change if the app directory is empty

### DIFF
--- a/chart/epinio/templates/stage-scripts.yaml
+++ b/chart/epinio/templates/stage-scripts.yaml
@@ -100,7 +100,7 @@ data:
     set -e
     trap "curl -X POST http://localhost:4191/shutdown 2> /dev/null || true" EXIT
     echo By _ _ __ ___ _____ $(whoami),$(id -u)/$(id -g) $(pwd)
-    if test ! -d "/workspace/source/app" ; then
+    if test ! -d "/workspace/source/app" || [ -z "$(ls -A /workspace/source/app)" ]; then
       echo Nothing to build
       sleep 60 # linkerd is a pain - If we exit to quickly, with the sidecar not ready our curl to shut it down does nothing, and then the sidecar comes up and prevents the pod from ending
       exit 1


### PR DESCRIPTION
This fixes an error i was having, where this test always passed, even if the `app` directory was empty.

The `/workspace/source/app` directory is actually created by an `unpack` script with `mkdir`, so unless this creation failed, this condition would never be met, even if `/workspace/source/app` was empty.

Before the fix: 

```
download-s3-blob: By _ _ __ ___ _____ root,0/0 /aws
download-s3-blob: Image amazon/aws-cli:2.13.26
download: s3://epinio/aebca871-1629-4895-8d81-898ea0909b6a to ../workspace/source/aebca871-1629-4895-8d81-898ea0909b6a
download-s3-blob: _ _ __ ___ _____ Done
unpack-blob: By _ _ __ ___ _____ root,0/0 /
unpack-blob: Image ghcr.io/epinio/epinio-unpacker:v1.11.0
unpack-blob: Tar?
unpack-blob: OK
unpack-blob: /stage-support/unpack: line 33: test: =: unary operator expected
unpack-blob: '/workspace/source/appenv/CNB_PLATFORM_API' -> '/workspace/source/env/CNB_PLATFORM_API'
unpack-blob: '/workspace/source/appenv/TEST' -> '/workspace/source/env/TEST'
unpack-blob: CNB_PLATFORM_API=0.14
unpack-blob: TEST=TEST1
unpack-blob: /workspace
unpack-blob: /workspace/source
unpack-blob: /workspace/source/appenv
unpack-blob: /workspace/source/appenv/..2025_02_05_14_24_41.3046269756
unpack-blob: /workspace/source/appenv/..2025_02_05_14_24_41.3046269756/CNB_PLATFORM_API
unpack-blob: /workspace/source/appenv/..2025_02_05_14_24_41.3046269756/TEST
unpack-blob: /workspace/source/appenv/..data
unpack-blob: /workspace/source/appenv/CNB_PLATFORM_API
unpack-blob: /workspace/source/appenv/TEST
unpack-blob: /workspace/source/app
unpack-blob: /workspace/source/env
unpack-blob: /workspace/source/env/CNB_PLATFORM_API
unpack-blob: /workspace/source/env/TEST
unpack-blob: /workspace/cache
unpack-blob: _ _ __ ___ _____ Done
buildpack: By _ _ __ ___ _____ heroku,1000/1000 /layers
buildpack: Setting registry access for Heroku builder
buildpack: /workspace
buildpack: /workspace/source
buildpack: /workspace/source/appenv
buildpack: /workspace/source/appenv/..2025_02_05_14_24_41.3046269756
buildpack: /workspace/source/appenv/..2025_02_05_14_24_41.3046269756/CNB_PLATFORM_API
buildpack: /workspace/source/appenv/..2025_02_05_14_24_41.3046269756/TEST
buildpack: /workspace/source/appenv/..data
buildpack: /workspace/source/appenv/CNB_PLATFORM_API
buildpack: /workspace/source/appenv/TEST
buildpack: /workspace/source/app
buildpack: /workspace/source/env
buildpack: /workspace/source/env/CNB_PLATFORM_API
buildpack: /workspace/source/env/TEST
buildpack: /workspace/cache
```

After the fix: 

```
download-s3-blob: By _ _ __ ___ _____ root,0/0 /aws
download-s3-blob: Image amazon/aws-cli:2.13.26
download: s3://epinio/fefdcb3a-25e9-4245-bf4a-c43a03d56b20 to ../workspace/source/fefdcb3a-25e9-4245-bf4a-c43a03d56b20
download-s3-blob: _ _ __ ___ _____ Done
unpack-blob: By _ _ __ ___ _____ root,0/0 /
unpack-blob: Image ghcr.io/epinio/epinio-unpacker:v1.11.0
unpack-blob: Tar?
unpack-blob: OK
unpack-blob: /stage-support/unpack: line 33: test: =: unary operator expected
unpack-blob: '/workspace/source/appenv/CNB_PLATFORM_API' -> '/workspace/source/env/CNB_PLATFORM_API'
unpack-blob: '/workspace/source/appenv/TEST' -> '/workspace/source/env/TEST'
unpack-blob: CNB_PLATFORM_API=0.14
unpack-blob: TEST=TEST1
unpack-blob: /workspace
unpack-blob: /workspace/source
unpack-blob: /workspace/source/appenv
unpack-blob: /workspace/source/appenv/..2025_02_05_14_31_05.2796454375
unpack-blob: /workspace/source/appenv/..2025_02_05_14_31_05.2796454375/TEST
unpack-blob: /workspace/source/appenv/..2025_02_05_14_31_05.2796454375/CNB_PLATFORM_API
unpack-blob: /workspace/source/appenv/..data
unpack-blob: /workspace/source/appenv/TEST
unpack-blob: /workspace/source/appenv/CNB_PLATFORM_API
unpack-blob: /workspace/source/app
unpack-blob: /workspace/source/env
unpack-blob: /workspace/source/env/CNB_PLATFORM_API
unpack-blob: /workspace/source/env/TEST
unpack-blob: /workspace/cache
unpack-blob: /workspace/cache/committed
unpack-blob: /workspace/cache/staging
unpack-blob: _ _ __ ___ _____ Done
buildpack: By _ _ __ ___ _____ heroku,1000/1000 /layers
buildpack: Setting registry access for Heroku builder
buildpack: Nothing to build
 ›   Error: Failed to stage application: Error: Staging failed

```