### PR TITLE
add scheduling and storage configurability to in-chart containre registry

### DIFF
--- a/chart/epinio/templates/container-registry-pvc.yaml
+++ b/chart/epinio/templates/container-registry-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.containerregistry.storage.emptyDir }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "epinio.fullname" . }}-registry
+spec:
+  accessModes:
+    {{- range .Values.containerregistry.storage.accessModes | default (list "ReadWriteOnce")}}
+    - {{ . }}
+    {{- end }}
+  {{- with .Values.containerregistry.storage.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.containerregistry.storage.size | default "1Gi" }}
+  volumeMode: {{ .Values.containerregistry.storage.volumeMode | default "Filesystem" }}
+{{- end }}

--- a/chart/epinio/templates/container-registry.yaml
+++ b/chart/epinio/templates/container-registry.yaml
@@ -8,7 +8,6 @@ metadata:
 stringData:
   # The only supported password format is bcrypt
   htpasswd:  {{ htpasswd .Values.global.registryUsername .Values.global.registryPassword | quote }}
-
 {{- if .Values.certManager.enabled }}
 ---
 apiVersion: cert-manager.io/v1
@@ -26,7 +25,6 @@ spec:
     name: epinio-ca
   secretName: epinio-registry-tls
 {{- end }}
-
 ---
 apiVersion: v1
 kind: Service
@@ -45,8 +43,6 @@ spec:
   - name: registry
     port: 5000
     targetPort: 5000
-
-{{ if .Values.containerregistry.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -82,8 +78,6 @@ data:
         proxy_pass https://localhost:5000/;
       }
     }
-{{- end }}
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -106,7 +100,6 @@ spec:
         app.kubernetes.io/instance: "epinio-registry"
     spec:
       containers:
-{{ if .Values.containerregistry.enabled }}
       - name: nginx
         image: "{{ template "registry-url" . }}{{ .Values.containerregistry.image.nginx.repository}}:{{ .Values.containerregistry.image.nginx.tag }}"
         imagePullPolicy: IfNotPresent
@@ -130,7 +123,6 @@ spec:
           name: nginx-run
         - mountPath: /var/run/
           name: nginx-run
-{{- end }}
       - name: registry
         image: "{{ template "registry-url" . }}{{ .Values.containerregistry.image.registry.repository}}:{{ .Values.containerregistry.image.registry.tag }}"
         imagePullPolicy: {{ .Values.containerregistry.imagePullPolicy }}
@@ -174,16 +166,24 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 5
+        {{- with .Values.containerregistry.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: registry
+        {{- if .Values.containerregistry.storage.emptyDir }}
         emptyDir: {}
+        {{ else }}
+        persistentVolumeClaim:
+          claimName: {{ include "epinio.fullname" . }}-registry
+        {{- end }}
       - name: auth
         secret:
           secretName: auth
       - name: certs
         secret:
           secretName: epinio-registry-tls
-{{ if .Values.containerregistry.enabled }}
       - name: nginx-conf
         configMap:
           name: nginx-conf
@@ -191,5 +191,16 @@ spec:
         emptyDir: {}
       - name: nginx-run
         emptyDir: {}
-{{- end }}
+      {{- with .Values.containerregistry.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.containerregistry.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.containerregistry.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -277,6 +277,38 @@ containerregistry:
   # The certificate has to be in PEM format within in a 'tls.crt' key (it can be an Opaque secret).
   # It also has to be trusted by the kubelet, and it needs to be added in the cluster as well.
   certificateSecret: ""
+  # Configure PVC or EmptyDir values for container registry storage
+  storage:
+    # If set to false, the values below will be used or defaulted
+    emptyDir: true
+    # size: 1Gi
+    # storageClassName: ""
+    # volumeMode: Filesystem
+    # accessModes:
+    # - ReadWriteOnce
+  resources: {}
+    # requests:
+    #   cpu: "200m"
+    #   memory: "1Gi"
+    # limits:
+    #   cpu: ""
+    #   memory: ""
+  nodeSelector: {}
+    # kubernetes.io/os: linux
+  affinity: {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: kubernetes.io/os
+    #         operator: In
+    #         values:
+    #         - linux
+  tolerations: []
+    # - key: "kubernetes.io/os"
+    #   operator: "Equal"
+    #   value: "linux"
+    #   effect: "NoSchedule"
 serviceCatalog:
   # Enable service catalog service for development
   enableDevServices: true


### PR DESCRIPTION
Add scheduling configs for container registry:
- resources
- nodeSelector
- affinity
- tolerations

Add storage configs for container registry
- emptyDir (true/false)
- size of PVC
- accessModes for PVC
- volumeMode for PVC
- storageClassName for PVC

Fallbacks supplied