### PR TITLE
chore: add kubeVersion constraint to epinio Chart.yaml

### DIFF
--- a/chart/epinio/Chart.yaml
+++ b/chart/epinio/Chart.yaml
@@ -30,6 +30,7 @@ dependencies:
   version: 0.14.0
 description: Epinio deploys Kubernetes applications directly from source code in one step.
 home: https://github.com/epinio/epinio
+kubeVersion: '>=1.21-0'
 icon: https://raw.githubusercontent.com/epinio/helm-charts/main/assets/epinio.png
 keywords:
 - epinio


### PR DESCRIPTION
## Summary

Adds a `kubeVersion: '>=1.21-0'` constraint to `chart/epinio/Chart.yaml`.

This is required for the Rancher partner-charts catalog submission so that the chart correctly declares its minimum Kubernetes version requirement.

## Related
- Prerequisite for adding epinio to the SUSE/Rancher partner-charts catalog
- Supersedes #feat/add-kubeVersion-constraint (had messy merge history)