### PR TITLE
Chore/bump reflector version

### DIFF
--- a/chart/epinio/Chart.yaml
+++ b/chart/epinio/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   repository: oci://ghcr.io/emberstack/helm-charts
   tags:
   - reflector
-  version: 9.1.45
+  version: 10.0.21
 - condition: s3gw.enabled, global.s3gw.enabled
   name: s3gw
   repository: https://s3gw-tech.github.io/s3gw-charts


### PR DESCRIPTION
Under certain conditions reflector would stop syncing causing namespaces to be created incorrectly, noticed this behavior during internal testing, bumping the reflector version fixes this issue. 