### PR TITLE
Add builder image CRD and upgrade hooks

### DIFF
--- a/chart/epinio/crds/app-crd.yaml
+++ b/chart/epinio/crds/app-crd.yaml
@@ -72,6 +72,8 @@ spec:
                     properties:
                       branch:
                         type: string
+                      gitconfig:
+                        type: string
                       provider:
                         type: string
                       repository:

--- a/chart/epinio/crds/builderimage-crd.yaml
+++ b/chart/epinio/crds/builderimage-crd.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: builderimages.application.epinio.io
+spec:
+  group: application.epinio.io
+  names:
+    kind: BuilderImage
+    listKind: BuilderImageList
+    plural: builderimages
+    singular: builderimage
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: BuilderImage is the Schema for the builderimages API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BuilderImageSpec defines the desired state of BuilderImage
+            properties:
+              image:
+                description: Image is the fully qualified Docker image reference
+                  (repository:tag) used to build applications with this builder image.
+                type: string
+              description:
+                description: Description of the builder image. Long form to be used in
+                  detailed displays.
+                type: string
+              shortDescription:
+                description: ShortDescription of the builder image. To be used in list
+                  displays.
+                type: string
+            required:
+            - image
+            type: object
+          status:
+            description: BuilderImageStatus defines the observed state of BuilderImage
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/epinio/crds/builderimage-crd.yaml
+++ b/chart/epinio/crds/builderimage-crd.yaml
@@ -47,6 +47,11 @@ spec:
                 description: ShortDescription of the builder image. To be used in list
                   displays.
                 type: string
+              default:
+                description: Default marks this builder image as the cluster default,
+                  used by staging when no explicit builder image is selected. Set by
+                  the helm-managed seed; not exposed through the public API.
+                type: boolean
             required:
             - image
             type: object

--- a/chart/epinio/templates/crd-upgrade.yaml
+++ b/chart/epinio/templates/crd-upgrade.yaml
@@ -1,0 +1,134 @@
+{{/*
+  CRD reconciliation hook.
+
+  Helm installs the files under `crds/` only on first install and never on
+  upgrade (https://helm.sh/docs/topics/charts/#limitations-on-crds). Because
+  this chart also seeds custom resources (AppChart, BuilderImage, Service),
+  the CRDs cannot be moved into `templates/`: Helm builds every rendered
+  object up front, so a seed CR of a not-yet-registered Kind fails REST
+  mapping on a fresh install.
+
+  To let `helm upgrade` pick up CRD changes, a pre-install/pre-upgrade hook
+  Job applies the same `crds/*.yaml` (single source of truth, embedded via
+  .Files.Glob) with kubectl and waits for them to be established. This runs
+  before the main manifest is applied, so schema changes to already-installed
+  CRDs (e.g. the new spec.origin.git.gitconfig field on `apps`) are reconciled
+  and reach existing clusters.
+
+  Caveat for a brand-new Kind (e.g. BuilderImage on a cluster that predates
+  it): this Job creates the CRD, but Helm REST-maps the *entire* main manifest
+  during upgrade preparation, before pre-upgrade hooks run. So a seed CR of a
+  not-yet-registered Kind that lives in the main manifest still fails at that
+  build step. Such a seed must itself be a post-install,post-upgrade hook so
+  it is applied after this Job has established the CRD. See default-builderimage.yaml.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "epinio-crd-upgrade-{{ .Release.Name }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "epinio.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "epinio-crd-upgrade-{{ .Release.Name }}"
+  labels:
+    {{- include "epinio.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "epinio-crd-upgrade-{{ .Release.Name }}"
+  labels:
+    {{- include "epinio.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: "epinio-crd-upgrade-{{ .Release.Name }}"
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "epinio-crd-upgrade-{{ .Release.Name }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "epinio-crd-upgrade-{{ .Release.Name }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "epinio.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+{{ (.Files.Glob "crds/*.yaml").AsConfig | indent 2 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "epinio-crd-upgrade-{{ .Release.Name }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "epinio.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      name: "epinio-crd-upgrade-{{ .Release.Name }}"
+      labels:
+        {{- include "epinio.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: "epinio-crd-upgrade-{{ .Release.Name }}"
+      # The kubectl image is shell-less, so each step is a direct kubectl
+      # invocation: apply the CRDs, then wait for them to be established
+      # before the main manifest (and its seed CRs) is applied.
+      initContainers:
+        - name: apply
+          image: "{{ include "registry-url" . }}{{ .Values.image.kubectl.repository }}:{{ .Values.image.kubectl.tag }}"
+          command: ["kubectl", "apply", "-f", "/crds/"]
+          volumeMounts:
+            - name: crds
+              mountPath: /crds
+      containers:
+        - name: wait-established
+          image: "{{ include "registry-url" . }}{{ .Values.image.kubectl.repository }}:{{ .Values.image.kubectl.tag }}"
+          command: ["kubectl", "wait", "--for=condition=established", "--timeout=90s", "-f", "/crds/"]
+          volumeMounts:
+            - name: crds
+              mountPath: /crds
+      volumes:
+        - name: crds
+          configMap:
+            name: "epinio-crd-upgrade-{{ .Release.Name }}"

--- a/chart/epinio/templates/default-builderimage.yaml
+++ b/chart/epinio/templates/default-builderimage.yaml
@@ -1,0 +1,15 @@
+apiVersion: application.epinio.io/v1
+kind: BuilderImage
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: standard
+  labels:
+    app.kubernetes.io/component: epinio
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: epinio-standard-builderimage
+    app.kubernetes.io/part-of: epinio
+    app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.image.epinio.tag }}
+spec:
+  shortDescription: Epinio standard builder image
+  description: Epinio standard builder image using the Paketo jammy full builder
+  image: "{{ .Values.image.builder.repository }}:{{ .Values.image.builder.tag }}"

--- a/chart/epinio/templates/default-builderimage.yaml
+++ b/chart/epinio/templates/default-builderimage.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/part-of: epinio
     app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.image.epinio.tag }}
 spec:
+  default: true
   shortDescription: Epinio standard builder image
   description: Epinio standard builder image using the Paketo jammy full builder
   image: "{{ .Values.image.builder.repository }}:{{ .Values.image.builder.tag }}"

--- a/chart/epinio/templates/default-builderimage.yaml
+++ b/chart/epinio/templates/default-builderimage.yaml
@@ -3,6 +3,17 @@ kind: BuilderImage
 metadata:
   namespace: {{ .Release.Namespace }}
   name: standard
+  # Applied as a post-install/post-upgrade hook so that on an upgrade which
+  # first introduces the BuilderImage CRD (see templates/crd-upgrade.yaml),
+  # the CRD is established by the pre-upgrade hook Job before this seed is
+  # built and applied. As a plain manifest it would fail REST mapping during
+  # Helm's up-front build of the main manifest. resource-policy: keep leaves
+  # the seed in place on uninstall; the hook re-applies (updates in place) on
+  # every upgrade.
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/resource-policy": keep
   labels:
     app.kubernetes.io/component: epinio
     app.kubernetes.io/instance: default


### PR DESCRIPTION
Added builder image CRD that pairs with the Epinio backend PR [here](https://github.com/epinio/epinio/pull/3019). I went ahead and also specified a default builder image to eventually replace some of the hard coded stuff in the UI & backend. 