### PR TITLE
Add Dockerfile build support for staging

### DIFF
--- a/chart/epinio/crds/app-crd.yaml
+++ b/chart/epinio/crds/app-crd.yaml
@@ -52,6 +52,12 @@ spec:
                   Epinio will use the builder image set by the user explicitly but
                   if one is not set, it will try to use the previously set image.
                 type: string
+              buildmode:
+                description: Staging build mode used for the last build (buildpack or dockerfile).
+                type: string
+              dockerfilepath:
+                description: Path to the Dockerfile used when buildmode is dockerfile.
+                type: string
               chartname:
                 description: ChartName stores the name of the application support
                   chart used to deploy the currently running application. This is

--- a/chart/epinio/templates/stage-scripts/stage-scripts.yaml
+++ b/chart/epinio/templates/stage-scripts/stage-scripts.yaml
@@ -82,6 +82,12 @@ data:
     rm "/workspace/source/${BLOBID}"
     mkdir -p /workspace/source/env
     cp -vL /workspace/source/appenv/* /workspace/source/env 2>/dev/null
+    # Dockerfile builds need env files inside the Kaniko context (/workspace/source/app).
+    # Buildpack mode must not pollute app source with plain env files.
+    if test -n "${DOCKERFILE_PATH}"; then
+      mkdir -p /workspace/source/app/env
+      cp -vL /workspace/source/appenv/* /workspace/source/app/env 2>/dev/null
+    fi
     for path in $(ls /workspace/source/env/* 2>/dev/null) ; do echo "$(basename "${path}")"="$(cat "${path}")" ; done
     chown -R ${USERID}:${GROUPID} /workspace 2> /dev/null
     find /workspace
@@ -144,10 +150,13 @@ data:
       echo "Dockerfile not found: ${DOCKERFILE}"
       exit 1
     fi
-    mkdir -p /kaniko/.docker
+    mkdir -p /kaniko/.docker /workspace/cache
     cp /home/cnb/.docker/config.json /kaniko/.docker/config.json
     REGISTRY="$(echo "${APPIMAGE}" | cut -d/ -f1)"
     /kaniko/executor \
+      --cache=true \
+      --cache-dir=/workspace/cache \
+      --cache-copy-layers=true \
       --context=/workspace/source/app \
       --dockerfile="/workspace/source/app/${DOCKERFILE}" \
       --destination="${APPIMAGE}" \

--- a/chart/epinio/templates/stage-scripts/stage-scripts.yaml
+++ b/chart/epinio/templates/stage-scripts/stage-scripts.yaml
@@ -19,6 +19,7 @@ data:
     CNB_PLATFORM_API: "0.11"
   downloadImage: "{{ default .Values.image.awscli.registry (include "registry-url" .) }}{{ .Values.image.awscli.repository}}:{{ .Values.image.awscli.tag }}"
   unpackImage:   "{{ default .Values.image.bash.registry (include "registry-url" .) }}{{ .Values.image.bash.repository}}:{{ default .Chart.AppVersion .Values.image.bash.tag }}"
+  dockerfileBuildImage: "{{ default .Values.image.dockerfileBuilder.registry (include "registry-url" .) }}{{ .Values.image.dockerfileBuilder.repository }}:{{ .Values.image.dockerfileBuilder.tag }}"
   download: |-
     # Parameters
     # - PROTOCOL # s3 protocol
@@ -123,3 +124,32 @@ data:
       "-previous-image=${PREIMAGE}" \
       "${APPIMAGE}"
       echo _ _ __ ___ _____ Done
+  dockerfile-build: |-
+    # Parameters
+    # - APPIMAGE        # url of application image
+    # - DOCKERFILE_PATH # path to Dockerfile within /workspace/source/app
+    #
+    # ATTENTION: The `curl localhost:4191` command is used to stop the linkerd proxy
+    # container gracefully. We use `|| true` in case linkerd is not deployed.
+    set -e
+    trap "wget -q -O - --post-data='' http://localhost:4191/shutdown 2> /dev/null || true" EXIT
+    echo By _ _ __ ___ _____ $(whoami),$(id -u)/$(id -g) $(pwd)
+    if test ! -d "/workspace/source/app" || [ -z "$(ls -A /workspace/source/app)" ]; then
+      echo Nothing to build
+      sleep 60
+      exit 1
+    fi
+    DOCKERFILE="${DOCKERFILE_PATH:-Dockerfile}"
+    if test ! -f "/workspace/source/app/${DOCKERFILE}" ; then
+      echo "Dockerfile not found: ${DOCKERFILE}"
+      exit 1
+    fi
+    mkdir -p /kaniko/.docker
+    cp /home/cnb/.docker/config.json /kaniko/.docker/config.json
+    REGISTRY="$(echo "${APPIMAGE}" | cut -d/ -f1)"
+    /kaniko/executor \
+      --context=/workspace/source/app \
+      --dockerfile="/workspace/source/app/${DOCKERFILE}" \
+      --destination="${APPIMAGE}" \
+      --skip-tls-verify-registry="${REGISTRY}"
+    echo _ _ __ ___ _____ Done

--- a/chart/epinio/values.yaml
+++ b/chart/epinio/values.yaml
@@ -48,6 +48,10 @@ image:
     # the builder image (and in supporting scripts).
     userid: 1001
     groupid: 1000
+  dockerfileBuilder:
+    registry: gcr.io/
+    repository: kaniko-project/executor
+    tag: v1.23.2-debug
 appChart:
   default: https://github.com/epinio/helm-charts/releases/download/epinio-application-0.1.26/epinio-application-0.1.26.tgz
 server:


### PR DESCRIPTION
Enable Dockerfile-based staging by adding CRD fields and Kaniko-based build script. Adds buildmode and dockerfilepath to the app CRD, a dockerfileBuilder image entry (gcr.io/kaniko-project/executor:v1.23.2-debug) to values.yaml, and a dockerfile-build stage script that validates the workspace, locates the Dockerfile, copies Docker config, and runs /kaniko/executor to build and push the APPIMAGE (with a shutdown trap for linkerd). Also exposes the dockerfileBuildImage template for use in staging.